### PR TITLE
Add TravisCi to enable continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+go: 
+  - "1.11.x"
+go_import_path: github.com/awslabs/aws-eks-cluster-controller
+git:
+  depth: false
+
+before_install:
+  - version=1.0.5 # latest stable version
+  - arch=amd64
+  - curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz
+  - tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
+  - mv kubebuilder_${version}_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
+  - export PATH=$PATH:/usr/local/kubebuilder/bin


### PR DESCRIPTION
*Description of changes:*
This is just a simple travis file that downloads our external dependencies (kubebuilder) and runs make.  More involved tests are out of the scope of this PR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
