### PR TITLE
Add role to the kubeconfig to enable cross account management

### DIFF
--- a/config/samples/components_v1alpha1_deployment.yaml
+++ b/config/samples/components_v1alpha1_deployment.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   # Add fields here
   cluster: eks-sample
+  name: nginx-deployment
+  namespace: default
   selector:
     matchLabels:
       app: nginx-deployment

--- a/pkg/authorizer/eks_test.go
+++ b/pkg/authorizer/eks_test.go
@@ -137,7 +137,7 @@ func Test_buildKubeconfig(t *testing.T) {
 			auth := &EKSAuthorizer{
 				log: zap.NewExample(),
 			}
-			got, err := auth.buildKubeconfig(tt.args.eksSvc, tt.args.clusterName)
+			got, err := auth.buildKubeconfig(tt.args.eksSvc, tt.args.clusterName, "roleArn")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildKubeconfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -172,6 +172,8 @@ users:
       - token
       - -i
       - Name1
+      - -r
+      - roleArn
       command: aws-iam-authenticator
       env: null
 `


### PR DESCRIPTION
*Description of changes:*
Add role to the kubeconfig to enable cross account management


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
