### PR TITLE
Added parallelization to controlplane and nodegroups

### DIFF
--- a/pkg/controller/controlplane/controlplane_controller.go
+++ b/pkg/controller/controlplane/controlplane_controller.go
@@ -59,7 +59,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("controlplane-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("controlplane-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 5})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/nodegroup/nodegroup_controller.go
+++ b/pkg/controller/nodegroup/nodegroup_controller.go
@@ -41,7 +41,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("nodegroup-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("nodegroup-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 5})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Issue #, if available:*
This mitigates #24, by moving N up for these resources to 5, from 1.

*Description of changes:*
Changed the configuration of the controller to run 5 reconciles in parallel.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
