### PR TITLE
Fix: Nodegroup role name is set incorrectly

### DIFF
--- a/pkg/controller/nodegroup/nodegroup_controller.go
+++ b/pkg/controller/nodegroup/nodegroup_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileNodeGroup) createNodeGroupStack(cfnSvc cloudformationiface.Clo
 		"ClusterName":           eks.Spec.ControlPlane.ClusterName,
 		"ControlPlaneStackName": "eks-" + eks.Spec.ControlPlane.ClusterName,
 		"AMI":                   eksOptimizedAMIs[eks.Spec.Region],
-		"NodeInstanceRoleName":  nodegroup.Name,
+		"NodeInstanceRoleName":  nodegroup.Name + "-role",
 	})
 
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Missed appending "-role" to the roleName while creating, fixed it here.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
