### PR TITLE
EKS will now delete components with label "eks.needsdeleting":"true",

### DIFF
--- a/pkg/controller/eks/components.go
+++ b/pkg/controller/eks/components.go
@@ -1,0 +1,78 @@
+package eks
+
+import (
+	"context"
+	"fmt"
+
+	componentsv1alpha1 "github.com/awslabs/aws-eks-cluster-controller/pkg/apis/components/v1alpha1"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var componentsToDelete = []runtime.Object{
+	&componentsv1alpha1.ConfigMapList{},
+	&componentsv1alpha1.DeploymentList{},
+	&componentsv1alpha1.IngressList{},
+	&componentsv1alpha1.SecretList{},
+	&componentsv1alpha1.ServiceList{},
+}
+
+func deleteComponents(ownerName, ownerNamespace string, c client.Client, logger *zap.Logger) (int, error) {
+
+	delete := []runtime.Object{}
+	for _, componentList := range componentsToDelete {
+		list := componentList.DeepCopyObject()
+		err := c.List(context.TODO(), client.MatchingLabels(map[string]string{
+			"eks.owner.name":      ownerName,
+			"eks.owner.namespace": ownerNamespace,
+			"eks.needsdeleting":   "true",
+		}), list)
+		if err != nil {
+			return 0, nil
+		}
+		switch l := list.(type) {
+		case *componentsv1alpha1.ConfigMapList:
+			for _, obj := range l.Items {
+				item := obj
+				delete = append(delete, &item)
+			}
+		case *componentsv1alpha1.DeploymentList:
+			for _, obj := range l.Items {
+				item := obj
+				delete = append(delete, &item)
+			}
+		case *componentsv1alpha1.IngressList:
+			for _, obj := range l.Items {
+				item := obj
+				delete = append(delete, &item)
+			}
+		case *componentsv1alpha1.SecretList:
+			for _, obj := range l.Items {
+				item := obj
+				delete = append(delete, &item)
+			}
+		case *componentsv1alpha1.ServiceList:
+			for _, obj := range l.Items {
+				item := obj
+				delete = append(delete, &item)
+			}
+		default:
+			logger.Error("Got object type we didn't understand", zap.Any("object", l))
+			return 0, fmt.Errorf("unknown type error")
+		}
+
+	}
+
+	errs := []error{}
+	for _, obj := range delete {
+		err := c.Delete(context.TODO(), obj)
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return len(delete), fmt.Errorf("error deleting objects %v", errs)
+	}
+
+	return len(delete), nil
+}

--- a/pkg/controller/eks/eks_controller.go
+++ b/pkg/controller/eks/eks_controller.go
@@ -230,7 +230,7 @@ func (r *ReconcileEKS) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	if instance.Status.Status != "Complete" {
 		instance.Status.Status = "Complete"
-
+		instance.Finalizers = finalizers.AddFinalizer(instance, ComponentsFinalizer)
 		err = r.Update(context.TODO(), instance)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/eks/eks_controller_test.go
+++ b/pkg/controller/eks/eks_controller_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awslabs/aws-eks-cluster-controller/pkg/finalizers"
-
 	clusterv1alpha1 "github.com/awslabs/aws-eks-cluster-controller/pkg/apis/cluster/v1alpha1"
 	componentsv1alpha1 "github.com/awslabs/aws-eks-cluster-controller/pkg/apis/components/v1alpha1"
 
@@ -134,9 +132,6 @@ func TestReconcile(t *testing.T) {
 	err = c.Create(context.TODO(), secret1)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	err = c.Create(context.TODO(), secret2)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	instance.Finalizers = finalizers.AddFinalizer(instance, ComponentsFinalizer)
-	err = c.Update(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	// Delete cluster

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -18,6 +18,9 @@ package service
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	clusterv1alpha1 "github.com/awslabs/aws-eks-cluster-controller/pkg/apis/cluster/v1alpha1"
 	componentsv1alpha1 "github.com/awslabs/aws-eks-cluster-controller/pkg/apis/components/v1alpha1"
@@ -30,14 +33,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 var (
@@ -83,9 +84,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// TODO(user): Modify this to be the types you create
-	// Uncomment watch a Deployment created by Service - change this for objects you create
-
 	return nil
 }
 
@@ -102,10 +100,6 @@ type ReconcileService struct {
 
 // Reconcile reads that state of the cluster for a Service object and makes changes based on the state read
 // and what is in the Service.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
-// a Deployment as an example
-// Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=components.eks.amazonaws.com,resources=services,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Service instance
@@ -150,22 +144,26 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		if finalizers.HasFinalizer(instance, ServiceFinalizer) {
 			log.Info("deleting service")
-			instance.Finalizers = finalizers.RemoveFinalizer(instance, ServiceFinalizer)
-			if err := r.Client.Update(context.TODO(), instance); err != nil {
-				return reconcile.Result{}, err
-			}
-
 			found := &corev1.Service{}
-			if err := client.Get(context.TODO(), remoteKey, found); err != nil {
+			err := client.Get(context.TODO(), remoteKey, found)
+			if err != nil && errors.IsNotFound(err) {
+				instance.Finalizers = finalizers.RemoveFinalizer(instance, ServiceFinalizer)
+				if err := r.Client.Update(context.TODO(), instance); err != nil {
+					return reconcile.Result{}, err
+				}
+				return reconcile.Result{}, nil
+			} else if err != nil {
 				log.Error("could not get remote service", zap.Error(err))
 				return reconcile.Result{}, nil
 			}
+
 			if err := client.Delete(context.TODO(), found); err != nil {
 				log.Error("could not delete remote service", zap.Error(err))
 			}
-			log.Info("service deleted")
 			return reconcile.Result{}, nil
+
 		}
+		return reconcile.Result{}, nil
 	}
 
 	rService := &corev1.Service{


### PR DESCRIPTION
Components defined in the pkg/controller/eks/components.go will now be
deleted if they have the correct label.  This will happen before
removing the nodegroups or cluster to allow for any remote
operators to clean up any existing resources.

Components were made to stick around until the remote
object is deleted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
