### PR TITLE
Don't assume the api-extenstion is register in the default scheme

### DIFF
--- a/pkg/controller/eks/components.go
+++ b/pkg/controller/eks/components.go
@@ -6,12 +6,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	crdv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func init() {
+	crdv1b1.AddToScheme(scheme.Scheme)
+}
 
 func deleteComponents(ownerName, ownerNamespace string, c client.Client, logger *zap.Logger) (count int, err error) {
 

--- a/pkg/controller/eks/eks_controller_suite_test.go
+++ b/pkg/controller/eks/eks_controller_suite_test.go
@@ -14,8 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	crdv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 var cfg *rest.Config
@@ -25,7 +23,6 @@ func TestMain(m *testing.M) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
 	}
 
-	crdv1b1.AddToScheme(scheme.Scheme)
 	apis.AddToScheme(scheme.Scheme)
 
 	var err error


### PR DESCRIPTION
This is a fix for error's listing CRDs

The apiextenstion scheme's are no longer assumed to be part of the default scheme.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
