### PR TITLE
Added correct rbac roles for deleting components.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ deploy: manifests
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+	# EKS doesn't allow pods to use the system:default SA, so replace with the default of the namespace
+	sed -i '' -e 's/namespace: system/namespace: aws-eks-cluster-controller-system/' config/rbac/rbac_role_binding.yaml
 
 # Run go fmt against code
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ deploy: manifests
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	# EKS doesn't allow pods to use the system:default SA, so replace with the default of the namespace
-	sed -i '' -e 's/namespace: system/namespace: aws-eks-cluster-controller-system/' config/rbac/rbac_role_binding.yaml
+	sed -i'' -e 's/namespace: system/namespace: aws-eks-cluster-controller-system/' config/rbac/rbac_role_binding.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -166,6 +166,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - components.eks.amazonaws.com
   resources:
   - configmaps

--- a/config/rbac/rbac_role_binding.yaml
+++ b/config/rbac/rbac_role_binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: aws-eks-cluster-controller-system

--- a/pkg/controller/eks/eks_controller.go
+++ b/pkg/controller/eks/eks_controller.go
@@ -123,6 +123,7 @@ type ReconcileEKS struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=cluster.eks.amazonaws.com,resources=controlplanes;nodegroups;ekss,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=components.eks.amazonaws.com,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ReconcileEKS) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the EKS instance


### PR DESCRIPTION
This fixes problems with the controller not able to list CRDs.  It also allows for the controller to use the correct SA.

*Description of changes:*
- Added read permissions to the controller role
- Added hack to ClusterRoleBinding to attach role to SA aws-eks-cluster-controller-system:default
    - This is done because EKS doesn't allow the use of system:default and the rbacgen doesn't allow overriding the SA that is used in the rbac.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
