### PR TITLE
trigger update when annotations change

### DIFF
--- a/pkg/controller/ingress/ingress_controller.go
+++ b/pkg/controller/ingress/ingress_controller.go
@@ -199,8 +199,11 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	log.Info("found remote ingress")
-	if !reflect.DeepEqual(found.Spec, rIngress.Spec) {
+	if !reflect.DeepEqual(found.Spec, rIngress.Spec) ||
+		!reflect.DeepEqual(found.Annotations, rIngress.Annotations) {
 		found.Spec = rIngress.Spec
+		found.Annotations = rIngress.Annotations
+
 		log.Info("updating ingress")
 		err := client.Update(context.TODO(), found)
 		if err != nil {


### PR DESCRIPTION
This PR adds a condition where the Remote Ingress resource will be updated when the federated ingress resource annotations change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
