### PR TITLE
Better nil checking in the kubeconfig generator.

### DIFF
--- a/pkg/authorizer/eks.go
+++ b/pkg/authorizer/eks.go
@@ -80,7 +80,7 @@ func (e *EKSAuthorizer) buildKubeconfig(eksSvc eksiface.EKSAPI, clusterName, rol
 		return nil, err
 	}
 
-	if r.Cluster.Name == nil || r.Cluster.Endpoint == nil || r.Cluster.CertificateAuthority.Data == nil {
+	if r.Cluster.Name == nil || r.Cluster.Endpoint == nil || r.Cluster.CertificateAuthority == nil || r.Cluster.CertificateAuthority.Data == nil {
 		log.Error("missing EKS cluster data", zap.String("cluster", clusterName))
 		return nil, fmt.Errorf("unable to build kubeconfig for cluster %s", clusterName)
 	}


### PR DESCRIPTION
In rare cases the controller will try to access an eks cluster before data is ready, causing causing a panic.  This patch fixes identified edge cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
