### PR TITLE
Fix: Increase start timeout to 60s for controlplane components in cir…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ before_install:
   - tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
   - mv kubebuilder_${version}_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
   - export PATH=$PATH:/usr/local/kubebuilder/bin
+env:
+  - KUBEBUILDER_CONTROLPLANE_START_TIMEOUT="60s"


### PR DESCRIPTION
Fix for https://circleci.com/gh/awslabs/aws-eks-cluster-controller/119

CircleCI tests were failing with kube-apiserver failed to start error. 

Increased the start timeout for all controlplane components including kube-api server


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
