### PR TITLE
Use the EKS control plane version for node group.

### DIFF
--- a/pkg/controller/nodegroup/nodegroup_controller.go
+++ b/pkg/controller/nodegroup/nodegroup_controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileNodeGroup) createNodeGroupStack(cfnSvc cloudformationiface.Clo
 	templateBody, err := awsHelper.GetCFNTemplateBody(nodeGroupCFNTemplate, nodeGroupTemplateInput{
 		ClusterName:           eks.Spec.ControlPlane.ClusterName,
 		ControlPlaneStackName: eks.GetControlPlaneStackName(),
-		AMI:                   GetAMI(nodegroup.GetVersion(), eks.Spec.Region),
+		AMI:                   GetAMI(*eks.Spec.ControlPlane.Version, eks.Spec.Region),
 		NodeInstanceName:      nodegroup.Name,
 		IAMPolicies:           nodegroup.Spec.IAMPolicies,
 	})


### PR DESCRIPTION
Use the EKS control plane version when selecting the node group AMI. This ensures the node group image selected is optimized for the correct cluster version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
