### PR TITLE
Nodeworker to use 2 t2.medium instances by default

### DIFF
--- a/pkg/controller/nodegroup/cfn_template.go
+++ b/pkg/controller/nodegroup/cfn_template.go
@@ -10,7 +10,7 @@ Parameters:
   NodeInstanceType:
     Description: EC2 instance type for the node instances
     Type: String
-    Default: m5.large
+    Default: t2.medium
     AllowedValues:
     - t2.small
     - t2.medium
@@ -77,7 +77,7 @@ Parameters:
   NodeAutoScalingGroupMaxSize:
     Type: Number
     Description: Maximum size of Node Group ASG.
-    Default: 3
+    Default: 2
 
   NodeVolumeSize:
     Type: Number


### PR DESCRIPTION
*Description of changes:*
Use only 2 t2.medium instances by default. 
We may need to add fields for this in NodeGroupSpec for future so user can have ability to pass when the CRD get created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
