### PR TITLE
Update remote service on annotations changes

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -202,8 +202,11 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	log.Info("found remote service")
-	if !reflect.DeepEqual(found.Spec, rService.Spec) {
+	if !reflect.DeepEqual(found.Spec, rService.Spec) ||
+		!reflect.DeepEqual(found.Annotations, rService.Annotations) {
 		found.Spec = rService.Spec
+		found.Annotations = rService.Annotations
+
 		log.Info("updating service")
 		err := client.Update(context.TODO(), found)
 		if err != nil {


### PR DESCRIPTION
*Description of changes:*
Kubernetes services now supports annotations to control the behavior of AWS load balancer https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer

We should have mechanism to update the service annotation in child cluster's service resource based on annotations provided in parent cluster's service.components.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
